### PR TITLE
Update Phoenix.Param docs (#1965)

### DIFF
--- a/lib/phoenix/param.ex
+++ b/lib/phoenix/param.ex
@@ -10,9 +10,9 @@ defprotocol Phoenix.Param do
   Phoenix knows how to extract the `:id` from `@user` thanks
   to this protocol.
 
-  By default, Phoenix implements this protocol for integers,
-  binaries, atoms, maps and structs. For maps and structs, a
-  key `:id` is looked up.
+  By default, Phoenix implements this protocol for integers, binaries, atoms,
+  and structs. For structs, a key `:id` is assumed, but you may provide a
+  specific implementation.
 
   Nil values cannot be converted to param.
 


### PR DESCRIPTION
Maps are explicitly not supported by this protocol.
